### PR TITLE
Fixann

### DIFF
--- a/src/entry
+++ b/src/entry
@@ -57,7 +57,7 @@ case "$order" in
         Rscript \
             --vanilla \
             -e "source('/GATTACA/src/__init__.R')" \
-            -e "source('/GATTACA/src/annotator.R')" \
+            -e "source('/GATTACA/src/tools/annotations.R')" \
             -e "setup_file_logging('/GATTACA/target', '${log_name}')" \
             -e "logger::log_threshold(${log_level})" \
             -e "selections <- strsplit('${4}', ',')[[1]]" \

--- a/src/tools/annotations.R
+++ b/src/tools/annotations.R
@@ -272,7 +272,7 @@ annotate_to_file <- function(
   ) |>
     log_debug()
 
-  source(file.path(ROOT, "src", "STALKER_Functions.R"))
+  source(file.path(ROOT, "src", "tools", "tools.R"))
   
   log_info("Loading input data...")
   expression_set <- read_expression_data(expression_data_path)

--- a/src/tools/annotations.R
+++ b/src/tools/annotations.R
@@ -246,7 +246,7 @@ annotate_data <- function(expression_set, chip_id, selections) {
     notMap[1,i] = sum(isNA(annotations[,i]))
     notMap[2,i] = round(notMap[1,i]/dim(annotations)[1]*1e2, digits = 2)
   }
-  log_info(paste("Missing annotations:", get.print.str(notMap), sep = "\n"))
+  log_info(paste("Missing annotations:", get.print.ind(notMap), sep = "\n``|| "))
   
   log_info("Merging annotations with the data...")
   merged_data <- merge_annotations(expression_set, annotations)

--- a/src/tools/annotations.R
+++ b/src/tools/annotations.R
@@ -227,7 +227,7 @@ annotate_data <- function(expression_set, chip_id, selections) {
   log_info("Finding annotations...")
   annotations <- get_remote_annotations(database_name, selections = selections)
   
-  # Check how many probes have no annotations
+  # Check the matching degree between array and annotation layouts 
   missing_probes <- sum(
     ! row.names(expression_set) %in% row.names(annotations)
   )
@@ -239,8 +239,14 @@ annotate_data <- function(expression_set, chip_id, selections) {
     ))
   }
   
-  # TODO : Maybe print out the number of NAs in the annotations for each
-  # type of annotation?
+  # Print out the number of NAs in the annotations for each type of annotation
+  notMap = matrix(0, nrow = 2, ncol = dim(annotations)[2],
+                  dimnames = list(c("NA entries","%"), colnames(annotations)))
+  for (i in colnames(annotations)) {
+    notMap[1,i] = sum(isNA(annotations[,i]))
+    notMap[2,i] = round(notMap[1,i]/dim(annotations)[1]*1e2, digits = 2)
+  }
+  log_info(paste("Missing annotations:", get.print.str(notMap), sep = "\n"))
   
   log_info("Merging annotations with the data...")
   merged_data <- merge_annotations(expression_set, annotations)

--- a/src/tools/tools.R
+++ b/src/tools/tools.R
@@ -97,6 +97,16 @@ get.print.str <- function(data) {
   return(paste0(capture.output(print(data)), collapse = "\n"))
 }
 
+#' Just like `get.print.str()` but providing a 5-chars indentation for logging.
+#'
+#' @param data Object to be printed.
+#'
+#' @returns A single string, with indentation chars.
+#'
+#' @author FeAR - MrHedmad
+get.print.ind <- function(data) {
+  return(paste0(capture.output(print(data)), collapse = "\n  || "))
+}
 
 #' Finds all the chars in `str1` that are also in `str2`,
 #' returning a vector of unique chars.


### PR DESCRIPTION
1 - Annotate module was broken because of some old references to some R scripts that do not exist anymore.
Now it works, but it would be better to review my changes.
2 - In addition I implemented the count of NA entries within the annotation dataframes retrieved from remote.
3 - Finally I made a variation of get.print.str() function named get.print.ind() to be used when printing tables in the log file inserting 5 chars of indentation in order to improve log readability. If you like it, we could extend to GATTACA main script (which produce a lot of tables!). Otherwise you can modify it or completely remove it if you think it's ugly or misleading.