### PR TITLE
GATTACA went on a diet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,4 @@ COPY ./ ./
 
 # Setup the entrypoint
 ENTRYPOINT [ "./src/entryswitch.sh" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,8 @@ RUN install2.r -n $(nproc --all) \
     tidyverse logger progress yaml statmod VennDiagram gplots UpSetR \
     testthat BiocManager && \
     /usr/local/lib/R/site-library/littler/examples/installBioc.r \
-    preprocessCore PCAtools limma RankProd oligo affycoretools EnhancedVolcano org.Hs.eg.db
-
-# Annotation layer - the most likely to be changed
-RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r \
-    hgu133a.db hgu133b.db hgu133plus2.db HsAgilentDesign026652.db hugene10sttranscriptcluster.db \
-    pd.hg.u133a pd.hg.u133b pd.hg.u133.plus.2 pd.hugene.1.0.st.v1 pd.drosophila.2
+    preprocessCore PCAtools limma RankProd oligo affycoretools EnhancedVolcano \
+    GEOquery
 
 # Copy the rest of the files
 COPY ./ ./

--- a/docs/src/document.tex
+++ b/docs/src/document.tex
@@ -2,7 +2,7 @@
 
 \notebox{\textbf{About the formatting of this document}: \mono{Monospace} text refers to a package, command, programming language or other programming-related concept. Text in {\color{glossary}green} refers to an entry in the glossary. Text in {\color{urlblue}this blue} is a link to an external source. Text in {\color{exturlblue}this blue} is a link to a section inside this document. Square brackets with {\color{citations}violet numbers} are citations.}
 
-\importantbox{This document covers \mono{GATTACA} version \mono{0.4.2}.}
+\importantbox{This document covers \mono{GATTACA} version \mono{0.5.2}.}
 
 \newpage
 
@@ -19,9 +19,9 @@ One of the most widely known and used tools to perform \gls{dea} is \mono{limma}
 
 Finally, microarray scanners will label the intensities with their respective probe IDs, while an human researcher prefers Gene Symbols (or \gls{hugo} symbols). This step is called \textit{annotation}, and requires the use of one of many annotation databases that hold the correspondences between probe IDs and Gene Symbols, among other.
 
-There is currently a need for a simple tool that can analyse microarray expression data to produce a list of \glspl{deg} using an intuitive, user friendly interface. We present \gls{gattaca}, a self-contained tool to prepare, analyse and annotate microarray gene expression data. An additional benefit of \gls{gattaca} is its reproducibility. Being containerized, the tool is guaranteed to be computationally reproducible.
+There is currently a need for a simple tool that can analyse microarray expression data to produce a list of \glspl{deg} using an intuitive, user friendly interface. We present \gls{gattaca}, a self-contained tool to prepare, analyse and annotate microarray gene expression data.
 
-One of the strengths of \gls{gattaca} is its user friendliness, so that any researcher, even without a background in bioinformatics or knowledge of \mono{R}, can correctly analyze both novel and pre-existing datasets.
+One of the strengths of \gls{gattaca} is its user friendliness, so that any researcher, even without a background in bioinformatics or knowledge of \mono{R}, can correctly analyze both novel and pre-existing datasets. Additionally, GATTACA provides computational reproducibility when performing \gls{dea}. By simply sharing one key configuration file, runs can be reproduced identically on different hardware or software.
 
 \gls{gattaca} is written in \mono{R}, containerized in Docker and fully Open-Source. The source code is \href{https://github.com/Feat-FeAR/GATTACA}{hosted on GitHub}. Users are encouraged to propose enhancements and report issues on the website. \gls{gattaca} runs only on unix-like operating systems.
 
@@ -141,7 +141,7 @@ The options are divided into sections. Each section controls different aspects o
         \item \textbf{\mono{plot\_height} (\mono{int})}: The height of the plots, in inches.
         \item \textbf{\mono{png\_resolution} (\mono{int})}: The pixels per inch of the png plots.
         \item \textbf{\mono{enumerate\_plots} (\mono{bool})}: If \mono{true}, each plot is marked with a number, in the order it is created.
-        \item \textbf{\mono{annotation\_chip\_id} (\mono{str})}: The "chip id" string of the chip used to find the \gls{hugo} symbols of the respective probes. A table of the available chip ids can be seen in table \ref{tab:chipids}.
+        \item \textbf{\mono{annotation\_chip\_id} (\mono{str})}: The \gls{geo} platform ID. This can be found by searching the \gls{geo} databases for the microarray used to analyse the samples. It follows the format \mono{GPLxxxx}, where \mono{xxxx} are a variable amount of numbers. The retrieved data is used to annotate both the output and Volcano Plots with Gene Symbols.
     \end{itemize}
     \item \textbf{\mono{switches}}: The switches section contains various parameters to turn parts of the analysis on or off:
     \begin{itemize}
@@ -165,22 +165,6 @@ The options are divided into sections. Each section controls different aspects o
         \end{itemize}
     \end{itemize}
 \end{itemize}
-
-\begin{table}
-    \centering
-    \begin{tabular}{|c|c|}
-        \hline
-        Chip ID & Microarray name \\ \hline
-        \mono{hgu133a} & Affymetrix Human Genome U133 Set (A) \\
-        \mono{hgu133b} & Affymetrix Human Genome U133 Set (B) \\
-        \mono{hgu133plus2} & Affymetrix Human Genome HG-U133 Plus 2.0 Array \\
-        \mono{HsAgilentDesign026652} & Agilent-026652 Whole Human Genome Microarray 4x44K v2 \\
-        \mono{hugene10st} & Affymetrix Human Gene 1.0-ST Array \\
-        \hline
-    \end{tabular}
-    \caption{Chip IDs and the corresponding microarrays. The chip id codes must be used instead of the longer names when using \gls{gattaca}.}
-    \label{tab:chipids}
-\end{table}
 
 \subsection{Running GATTACA}
 Once the options file is created and edited, the process of running \mono{gattaca} is simple:
@@ -272,20 +256,20 @@ The various batches can be specified with the \mono{design > batches} variable.
 For most applications, the \mono{markings} column can be used to retrieve up- and down-regulated genes in each contrast for each tool. Comparisons of the number of genes detected by the two tools are available in the quality control plots.
 
 \section{Annotating Results}
-Investigators are often interested in annotating their results with metadata. \gls{gattaca} provides the \mono{annotate} command to annotate any \mono{.csv} file with a \mono{probe\_id} column with annotations from Bioconductor databases for each chip.
+Investigators are often interested in annotating their results with metadata. \gls{gattaca} provides the \mono{annotate} command to annotate any \mono{.csv} file with a \mono{probe\_id} column with annotations from \gls{geo} databases for each chip.
 
 The command is invoked as such:
 \begin{lstlisting}
-GATTACA annotate [-h | --help] [-s | --select <selections>] <input_file>
-                 <output_file> <chip_id>
+GATTACA annotate [-h | --help] <input_file> <output_file> <chip_id>
 \end{lstlisting}
 \begin{itemize}
     \item The \mono{-h | --help} ends the command early and shows usage statistics.
-    \item The \mono{-s | --select <selections>} option can be used to select the metadata to annotate. The possible variables that can sourced from most databases are \mono{ACCNUM}, \mono{CHR}, \mono{CHRLOC}, \mono{CHRLOCEND}, \mono{ENSEMBL}, \mono{ENTREZID}, \mono{ENZYME}, \mono{GENENAME}, \mono{GO}, \mono{MAP}, \mono{OMIM}, \mono{PATH}, \mono{PMID}, \mono{REFSEQ}, \mono{SYMBOL} and \mono{UNIPROT}.
     \item \mono{<input\_file>} must be replaced with the (full) path to the input \mono{.csv} file to annotate.
     \item \mono{<output\_file>} must be replaced with the (full) path to the output \mono{.csv} file.
-    \item \mono{<chip\_id>} must be replaced with a valid chip id. The supported chips are available in Table \ref{tab:chipids}.
+    \item \mono{<chip\_id>} must be replaced with the \gls{geo} platform ID. This can be found by searching the \gls{geo} databases for the microarray used to analyse the samples. It follows the format \mono{GPLxxxx}, where \mono{xxxx} are a variable amount of numbers. The retrieved data is used to annotate both the output and Volcano Plots with Gene Symbols.
 \end{itemize}
+
+Currently, annotating with data not found as a \gls{geo} platform in not supported.
 
 \section{Quality control plots}
 \label{sec:QCplots}

--- a/docs/src/resources/glossary.tex
+++ b/docs/src/resources/glossary.tex
@@ -57,3 +57,4 @@
 \newacronym{pfp}{PFP}{Proportion of False Positives}
 \newacronym{gam}{GAM}{Generalized Additive Model}
 \newacronym{hugo}{HUGO}{\underline{Hu}man \underline{G}enome \underline{O}rganization}
+\newacronym{geo}{GEO}{Gene Expression Omnibus}

--- a/src/GATTACA.R
+++ b/src/GATTACA.R
@@ -505,8 +505,8 @@ diagnose_limma_data <- function(
     volcano_p_threshold = find_BH_critical_p(DEGs.limma[[i]]$adj.P.Val)
 
     # Enhanced Volcano Plot
-    if ("SYMBOL" %in% colnames(DEGs.limma[[i]])) {
-      volcano_labels <- DEGs.limma[[i]]$SYMBOL
+    if ("Gene Symbol" %in% colnames(DEGs.limma[[i]])) {
+      volcano_labels <- DEGs.limma[[i]]$`Gene Symbol`
     } else {
       volcano_labels = rownames(DEGs.limma[[i]])
     }
@@ -871,8 +871,8 @@ diagnose_rankprod_data <- function(
   log_info("Making RankProd Volcano plots...")
   for (i in seq_along(contrasts)) {
     # Enhanced Volcano Plot
-    if ("SYMBOL" %in% colnames(DEGs.rankprod[[i]])) {
-      volcano_labels <- DEGs.rankprod[[i]]$SYMBOL
+    if ("Gene Symbol" %in% colnames(DEGs.rankprod[[i]])) {
+      volcano_labels <- DEGs.rankprod[[i]]$`Gene Symbol`
     } else {
       volcano_labels = rownames(DEGs.rankprod[[i]])
     }
@@ -988,10 +988,14 @@ GATTACA <- function(options.path, input.file, output.dir) {
   )
 
   if (getOption("use.annotations")) {
-    annotation_data <- get_remote_annotations(
-      CHIP_TO_DB[[opts$general$annotation_chip_id]], "SYMBOL"
-    )
-    log_info("Annotations loaded.")
+    log_info("Loading annotations...")
+    annotation_data <- get_annotations_from_GEO(opts$general$annotation_chip_id)
+    if (! "Gene Symbol" %in% colnames(annotation_data)) {
+      log_warn("The 'Gene Symbol' column was not found. Cannot annotate output.")
+      options(use.annotations = FALSE)
+    } else {
+      annotation_data <- annotation_data[, "Gene Symbol", drop=FALSE]
+    }
   } else {
     log_info("No annotations loaded.")
   }

--- a/src/__init__.R
+++ b/src/__init__.R
@@ -63,6 +63,7 @@ setwd(ROOT)
 # overwrite functions (!!).
 
 # These two are backbone packages.
+log_info("Loading minimum packages...")
 suppressMessages(library(tidyverse))
 suppressMessages(library(progress))
 
@@ -72,11 +73,11 @@ suppressMessages(library(progress))
 #'
 #' @author MrHedmad
 graceful_load <- function(packages) {
-  log_info("Loading required packages...")
+  log_info("Loading additional required packages...")
   log_debug("Loading packages:", paste(packages, collapse = ", "))
 
   pb <- progress_bar$new(
-    format = "Loading... [:bar] :percent (:eta)",
+    format = "Loading... [:bar] :current/:total (:eta)",
     total = length(packages), clear = FALSE, width= 80)
   pb$tick(0)
   for (i in seq_along(packages)) {
@@ -102,8 +103,7 @@ graceful_load(c(
   "oligo",            # Prepare agilent things
   "affycoretools",    # Filter out the affy control probes
   "reshape2",         # Reshaping functions
-  "AnnotationDbi",    # Base for the annotations
-  "org.Hs.eg.db"      # Base reader for all SQL packages
+  "GEOquery"          # Retrieve data from GEO dynamically
 ))
 
 source(file.path(ROOT, "src", "tools", "tools.R"))

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -68,17 +68,11 @@ function _gattaca_help_prepaffy {
 
 
 function _gattaca_help_annotate {
-    echo "Usage: GATTACA annotate [-h | --help] [-s | --select <selections>] <input_file>"
-    echo "       <output_file> <chip_id>"
+    echo "Usage: GATTACA annotate [-h | --help] <input_file> <output_file> <chip_id>"
     echo
     echo "Annotate an expression dataset '<input_file>' with annotations for the chip <chip_id>."
+    echo "The Chip ID is the GEO accession number for the platform (e.g. GPL0000)"
     echo "Save the output in <output_file>."
-    echo "Read the README for a list of the supported chips for each container version."
-    echo
-    echo "Options:"
-    echo "  -s | --select <selections>         Comma delimited list of selections. Defaults to"
-    echo "                                     'SYMBOL,GENENAME', annotating HUGO symbols and long"
-    echo "                                     gene names."
 }
 
 
@@ -302,11 +296,6 @@ function _gattaca_run_annotate {
                 _gattaca_help_annotate
                 exit 0
             ;;
-            -s | --select)
-                shift
-                selections="$1"
-                shift
-            ;;
             * )
                 break
             ;;
@@ -341,7 +330,7 @@ function _gattaca_run_annotate {
         --mount type=bind,source="$input_mountpoint",target=/GATTACA/input,readonly \
         cmalabscience/gattaca:"$version" \
         "$log_name" "$log_level" \
-        "annotate" "$input_filename" "$output_filename" "$chip_id" "$selections"
+        "annotate" "$input_filename" "$output_filename" "$chip_id"
 }
 
 function _gattaca_run_prepagil {

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -49,7 +49,7 @@ case "$order" in
             -e "affy2expression('/GATTACA/input', '${outputfile}', remove.controls = ${2}, plot.width = sizes[1], plot.height = sizes[2], use.pdf = ${4}, n_plots = ${5})"
         ;;
     annotate)
-        # "$input_filename" "$output_filename" "$chip_id" "$selections"
+        # "$input_filename" "$output_filename" "$chip_id"
         outputfile="/GATTACA/target/${2}"
         inputfile="/GATTACA/input/${1}"
 
@@ -59,8 +59,7 @@ case "$order" in
             -e "source('/GATTACA/src/tools/annotations.R')" \
             -e "setup_file_logging('/GATTACA/target', '${log_name}')" \
             -e "logger::log_threshold(${log_level})" \
-            -e "selections <- strsplit('${4}', ',')[[1]]" \
-            -e "annotate_to_file(expression_data_path = '${inputfile}', output_path = '${outputfile}', chip_id = '${3}', selections = selections)"
+            -e "annotate_to_file(expression_data_path = '${inputfile}', output_path = '${outputfile}', chip_id = '${3}')"
         ;;
     prepagil)
         # "$output_filename" "$grep_pattern" "$remove_controls" "$plot_size" "$use_pdf" "$plot_number"

--- a/src/resources/GATTACA_default_options.yaml
+++ b/src/resources/GATTACA_default_options.yaml
@@ -31,13 +31,8 @@ general:
   # as they use HUGO symbols instead of probe IDs, and the output data will
   # be annotated with the related HUGO symbols.
   # Specify here one available annotation ID based on your chip.
+  # Use the GEO accession number (GPLnnnn) for the Platform you are using.
   # Leave to `null` to not annotate.
-  # Available annotations (chip_name -> id):
-  # Affymetrix Human Genome U133 Set (A) -> hgu133a
-  # Affymetrix Human Genome U133 Set (B) -> hgu133b
-  # Affymetrix Human Genome HG-U133 Plus 2.0 Array -> hgu133plus2
-  # Agilent-026652 Whole Human Genome Microarray 4x44K v2 -> HsAgilentDesign026652
-  # Affymetrix Human Gene 1.0-ST Array -> hugene10st
   annotation_chip_id: null # null OR str
 
 


### PR DESCRIPTION
The inclusion of annotation packages in the image is too much of a burden, both from the point of view of image size and the amount of rebuilds needed, so I got rid of them.

Additionally, I found the `GEOquery` package that can parse (very very quickly, too) annotation data from GEO directly, given the platform ID (from GEO, like `GPL1234`).
So, there is no need to install annotation packages from BioC and parse them (like we did earlier), we just look up the info on GEO. This has the added benefit that the platforms IDs are already there while downloading projects.
